### PR TITLE
fix: resource name regex fixup

### DIFF
--- a/cmd/protoc-gen-netlify-cms/main.go
+++ b/cmd/protoc-gen-netlify-cms/main.go
@@ -397,7 +397,8 @@ func inferField(
 			field.Widget.RequiredValue = true
 			if len(resource.Pattern) > 0 {
 				pattern := resource.Pattern[0]
-				exp := regexp.MustCompile(`{.*}`).ReplaceAllString(pattern, `^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$`)
+				exp := regexp.MustCompile(`{.*}`).ReplaceAllString(pattern, `[a-z0-9][a-z0-9-]{0,61}[a-z0-9]`)
+				exp = fmt.Sprintf("^%v$", exp)
 				field.Widget.Pattern = &cmsv1.Widget_Pattern{
 					Regexp:       exp,
 					ErrorMessage: "Must match " + exp,


### PR DESCRIPTION
Change the resource name regex from

`books/^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$`

to

`^books/[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$`

as the old format is not working with regex check.