### PR TITLE
feat: make inferred numeric types required

### DIFF
--- a/cmd/protoc-gen-netlify-cms/main.go
+++ b/cmd/protoc-gen-netlify-cms/main.go
@@ -479,6 +479,7 @@ func inferField(
 		return field, len(objectFields) > 0
 	case (protoField.Desc.Kind() == protoreflect.DoubleKind ||
 		protoField.Desc.Kind() == protoreflect.FloatKind) && !protoField.Desc.IsList():
+		field.Widget.RequiredValue = true // required since Netlify uses empty string for no value instead of 0
 		field.Widget.WidgetType = &cmsv1.Widget_NumberWidget{
 			NumberWidget: &cmsv1.NumberWidget{
 				ValueType: cmsv1.NumberWidget_FLOAT,
@@ -487,6 +488,7 @@ func inferField(
 		return field, true
 	case (protoField.Desc.Kind() == protoreflect.Int64Kind ||
 		protoField.Desc.Kind() == protoreflect.Int32Kind) && !protoField.Desc.IsList():
+		field.Widget.RequiredValue = true // required since Netlify uses empty string for no value instead of 0
 		field.Widget.WidgetType = &cmsv1.Widget_NumberWidget{
 			NumberWidget: &cmsv1.NumberWidget{
 				ValueType: cmsv1.NumberWidget_INT,

--- a/proto/gen/cms/einride/netlify/cms/example/v1/config.yml
+++ b/proto/gen/cms/einride/netlify/cms/example/v1/config.yml
@@ -135,7 +135,7 @@ collections:
       - name: "double_value"
         label: "DOUBLE VALUE"
         comment: "A double value."
-        required: false
+        required: true
         hint: "A double value."
         widget: "number"
         value_type: "float"
@@ -143,7 +143,7 @@ collections:
       - name: "float_value"
         label: "FLOAT VALUE"
         comment: "A float value."
-        required: false
+        required: true
         hint: "A float value."
         widget: "number"
         value_type: "float"
@@ -151,7 +151,7 @@ collections:
       - name: "int64_value"
         label: "INT64 VALUE"
         comment: "An int64 value."
-        required: false
+        required: true
         hint: "An int64 value."
         widget: "number"
         value_type: "int"


### PR DESCRIPTION
Since Netlify uses `""` instead of `0` for absent values, numeric fields
must be required in order for Netlify and protobuf semantics to be fully
compatible.
