### PR TITLE
Fix/collapsed and multiple fixes

### DIFF
--- a/cmd/protoc-gen-netlify-cms/main.go
+++ b/cmd/protoc-gen-netlify-cms/main.go
@@ -466,7 +466,7 @@ func inferField(
 		}
 		field.Widget.WidgetType = &cmsv1.Widget_ObjectWidget{
 			ObjectWidget: &cmsv1.ObjectWidget{
-				Collapsed: true,
+				Collapsed: !inferRequired(protoField),
 				Summary:   "", // TODO
 				Fields:    objectFields,
 			},
@@ -486,7 +486,7 @@ func inferField(
 		field.Widget.WidgetType = &cmsv1.Widget_ListWidget{
 			ListWidget: &cmsv1.ListWidget{
 				AllowAdd:          true,
-				Collapsed:         true,
+				Collapsed:         !inferRequired(protoField),
 				MinimizeCollapsed: true,
 				Fields:            objectFields,
 			},

--- a/cmd/protoc-gen-netlify-cms/main.go
+++ b/cmd/protoc-gen-netlify-cms/main.go
@@ -208,6 +208,7 @@ func genField(g *generatedYAMLFile, field *cmsv1.Field) {
 		if len(widget.SelectWidget.DefaultValue) == 1 {
 			g.Y("default: ", strconv.Quote(widget.SelectWidget.DefaultValue[0]))
 		}
+		g.Y("multiple: ", widget.SelectWidget.Multiple)
 		g.Y("options:")
 		g.Up()
 		for _, option := range widget.SelectWidget.Options {
@@ -435,7 +436,9 @@ func inferField(
 		return field, true
 	case protoField.Desc.Kind() == protoreflect.EnumKind:
 		field.Widget.WidgetType = &cmsv1.Widget_SelectWidget{
-			SelectWidget: &cmsv1.SelectWidget{},
+			SelectWidget: &cmsv1.SelectWidget{
+				Multiple: protoField.Desc.IsList(),
+			},
 		}
 		var options []*cmsv1.SelectWidget_Option
 		for i := 0; i < protoField.Desc.Enum().Values().Len(); i++ {

--- a/proto/gen/cms/einride/netlify/cms/example/v1/config.yml
+++ b/proto/gen/cms/einride/netlify/cms/example/v1/config.yml
@@ -126,6 +126,7 @@ collections:
         required: true
         hint: "An example enum."
         widget: "select"
+        multiple: false
         options:
           - label: "ONE"
             value: "ONE"


### PR DESCRIPTION
- Fixes an issue causing repeated enum fields to not be multi-select causing result to be string instead of list of strings.
- Changes behaviour of required collections (Object/List widget) so that they are not collapsed by default if the message is required.