### PR TITLE
fix(security): bump go version to 1.25.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
+        with:
+          go-version-file: go.mod
 
       - name: Make
         run: make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Setup Sage
         uses: einride/sage/actions/setup@master
+        with:
+          go-version-file: go.mod
 
       - name: Make
         run: make

--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -1,5 +1,5 @@
 module go.einride.tech/protobuf-decap-cms/.sage
 
-go 1.24.9
+go 1.25.5
 
 require go.einride.tech/sage v0.387.0

--- a/.sage/main.go
+++ b/.sage/main.go
@@ -11,7 +11,7 @@ import (
 	"go.einride.tech/sage/tools/sgconvco"
 	"go.einride.tech/sage/tools/sggit"
 	"go.einride.tech/sage/tools/sggo"
-	"go.einride.tech/sage/tools/sggolangcilint"
+	"go.einride.tech/sage/tools/sggolangcilintv2"
 	"go.einride.tech/sage/tools/sggoreleaser"
 	"go.einride.tech/sage/tools/sggosemanticrelease"
 	"go.einride.tech/sage/tools/sgmdformat"
@@ -54,7 +54,7 @@ func GoTest(ctx context.Context) error {
 
 func GoLint(ctx context.Context) error {
 	sg.Logger(ctx).Println("linting Go files...")
-	return sggolangcilint.Run(ctx)
+	return sggolangcilintv2.Run(ctx, sggolangcilintv2.Config{})
 }
 
 func FormatMarkdown(ctx context.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.einride.tech/protobuf-decap-cms
 
-go 1.23
+go 1.25.5
 
 require (
 	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37


### PR DESCRIPTION
VEH-3334

This PR was generated with [multipr](https://github.com/fredrikaverpil/multipr)
