### PR TITLE
fix(security): bump go version to 1.25.7

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -1,5 +1,5 @@
 module go.einride.tech/protobuf-decap-cms/.sage
 
-go 1.24.9
+go 1.25.7
 
 require go.einride.tech/sage v0.391.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.einride.tech/protobuf-decap-cms
 
-go 1.23
+go 1.25.7
 
 require (
 	google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37


### PR DESCRIPTION
VEH-3550

This PR was generated with [multipr](https://github.com/fredrikaverpil/multipr)
